### PR TITLE
Python3: command in binary, result file binary

### DIFF
--- a/webodt/converters/abiword.py
+++ b/webodt/converters/abiword.py
@@ -15,6 +15,7 @@ class AbiwordODFConverter(ODFConverter):
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         args = (document.name, output_filename, format)
-        process.communicate('convert %s %s %s\n' % args)
-        fd = Document(output_filename, mode='r', delete_on_close=delete_on_close)
+        command = "convert %s %s %s" % args
+        process.communicate(bytes(command, 'ascii'))
+        fd = Document(output_filename, mode='rb', delete_on_close=delete_on_close)
         return fd


### PR DESCRIPTION
I found it working when I encode command as binary. 
Also I had to change the result file to binary in order to PDFs getting generated correctly